### PR TITLE
Fix Braintree Paypal

### DIFF
--- a/app/components/checkout/braintree/BraintreePayments.tsx
+++ b/app/components/checkout/braintree/BraintreePayments.tsx
@@ -54,7 +54,7 @@ export function BraintreeDropIn(props: {
                         container: '#braintree-drop-in-div',
                         paypal: {
                             flow: 'checkout',
-                            amount: fullAmount,
+                            amount: fullAmount / 100,
                             currency: currencyCode.toString(),
                         },
                     },


### PR DESCRIPTION
Paypal needs the total amount for checkout.
Last PR I forgot that full amount is not decimal in vendure, so the price shown in paypal was 100x too high.
I fix this this by just dividing by 100. Is this fine to do for all currencies?