### PR TITLE
chore: Create env template and update readme

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,9 @@
+# The URL for the Vendure API.
+# You can use your local server (e.g., http://localhost:3000/shop-api) or our public demo server for testing: https://readonlydemo.vendure.io/shop-api
+VENDURE_API_URL=http://localhost:3000/shop-api
+
+# The environment in which the application is running (e.g., development, production)
+NODE_ENV=development
+
+# The default port for the storefront
+PORT=8000

--- a/.env.template
+++ b/.env.template
@@ -6,4 +6,4 @@ VENDURE_API_URL=http://localhost:3000/shop-api
 NODE_ENV=development
 
 # The default port for the storefront
-PORT=8000
+PORT=8002

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For a more detailed guide on how to work with code generation, check the wiki ab
 
 #### Local
 
-You can set up a local instance, populated with test data by following the instructions in the Vendure [Getting Started guide](https://www.vendure.io/docs/getting-started/). Note that make sure you have enabled the `bearer` method for managing session tokens:
+You can set up a local instance, populated with test data by following the instructions in the Vendure [Getting Started guide](https://docs.vendure.io/getting-started/). Note that make sure you have enabled the `bearer` method for managing session tokens:
 
 ```ts
 // vendure-config.ts
@@ -68,7 +68,7 @@ Currently, both Stripe and Braintree are supported out of the box, but only one 
 ### Stripe integration
 
 This repo has a built-in Stripe payment integration. To enable it, ensure that your Vendure server is set up with
-the [StripePlugin](https://docs.vendure.io/reference/core-plugins/payments-plugin/stripe-plugin).
+the [StripePlugin](https://docs.vendure.io/reference/core-plugins/payments-plugin/stripe-plugin/).
 
 Ensure your new PaymentMethod uses the word `stripe` somewhere in its code, as that's how this integration will know
 to load the Stripe payment element.
@@ -84,7 +84,7 @@ STRIPE_PUBLISHABLE_KEY=pk_test_...
 ### Braintree integration
 
 This repo has built-in Braintree integration. To enable it, ensure that your Vendure server is set up with
-the [BraintreePlugin](https://docs.vendure.io/reference/core-plugins/payments-plugin/braintree-plugin).
+the [BraintreePlugin](https://docs.vendure.io/reference/core-plugins/payments-plugin/braintree-plugin/).
 
 Currently, `storeCustomersInBraintree` has to be set to `true` in plugin options.
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,9 @@ General things missing:
 
 1. Clone this repo
 2. `yarn install`
-3. Create a `.env` file in the root dir with the following contents:
-   ```.env
-   VENDURE_API_URL=http://localhost:3001/shop-api
-   # or
-   # VENDURE_API_URL=https://readonlydemo.vendure.io/shop-api
-   NODE_ENV=development
+3. Create a `.env` file in the root dir with the following command and update it with your variables:
+   ```bash
+   cp .env.template .env
    ```
 4. `yarn dev` - run the storefront with a local Remix server
 5. `yarn dev:cf` - runs locally with the Cloudflare Pages configuration
@@ -51,15 +48,11 @@ For a more detailed guide on how to work with code generation, check the wiki ab
 
 #### Local
 
-You can set up a local instance, populated with test data by following the instructions in the Vendure [Getting Started guide](https://www.vendure.io/docs/getting-started/). Note that since Remix runs on port 3000 by default, you should change the local Vendure server to run on another port, and also make sure you have enabled the `bearer` method for managing session tokens:
+You can set up a local instance, populated with test data by following the instructions in the Vendure [Getting Started guide](https://www.vendure.io/docs/getting-started/). Note that make sure you have enabled the `bearer` method for managing session tokens:
 
 ```ts
 // vendure-config.ts
 export const config: VendureConfig = {
-  apiOptions: {
-    port: 3001,
-    // ...
-  },
   authOptions: {
     tokenMethod: ['bearer', 'cookie'], // or just 'bearer'
     // ...
@@ -75,7 +68,7 @@ Currently, both Stripe and Braintree are supported out of the box, but only one 
 ### Stripe integration
 
 This repo has a built-in Stripe payment integration. To enable it, ensure that your Vendure server is set up with
-the [StripePlugin](https://www.vendure.io/docs/typescript-api/payments-plugin/stripe-plugin/).
+the [StripePlugin](https://docs.vendure.io/reference/core-plugins/payments-plugin/stripe-plugin).
 
 Ensure your new PaymentMethod uses the word `stripe` somewhere in its code, as that's how this integration will know
 to load the Stripe payment element.
@@ -83,7 +76,7 @@ to load the Stripe payment element.
 Then add your Stripe publishable key to the env file:
 
 ```
-STRIPE_PUBLISHABLE_KEY=pk_test_t38hl...etc
+STRIPE_PUBLISHABLE_KEY=pk_test_...
 ```
 
 **Important note**: There's a race condition between Stripe redirecting a customer to the confirmation page and the webhook receiving the confirmation in the Vendure backend. As this condition is not very distinguishable from other potential issues, it is currently addressed by implementing a very simple retry system of 5 retries every 2.5s You can tweak these settings in the [CheckoutConfirmation route](./app/routes/checkout/confirmation.%24orderCode.tsx).
@@ -91,7 +84,7 @@ STRIPE_PUBLISHABLE_KEY=pk_test_t38hl...etc
 ### Braintree integration
 
 This repo has built-in Braintree integration. To enable it, ensure that your Vendure server is set up with
-the [BraintreePlugin](https://www.vendure.io/docs/typescript-api/payments-plugin/braintree-plugin/).
+the [BraintreePlugin](https://docs.vendure.io/reference/core-plugins/payments-plugin/braintree-plugin).
 
 Currently, `storeCustomersInBraintree` has to be set to `true` in plugin options.
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ General things missing:
 1. Clone this repo
 2. `yarn install`
 3. Create a `.env` file in the root dir with the following command and update it with your variables:
+   
    ```bash
    cp .env.template .env
    ```
-4. `yarn dev` - run the storefront with a local Remix server
-5. `yarn dev:cf` - runs locally with the Cloudflare Pages configuration
+   
+5. `yarn dev` - run the storefront with a local Remix server
+6. `yarn dev:cf` - runs locally with the Cloudflare Pages configuration
 
 ### Vendure Server
 


### PR DESCRIPTION
We should not change the API running port for a storefront, instead we can specify a storefront running port to resolve conflicts🤔