### PR TITLE
Fix badge number overlap when count is 100+

### DIFF
--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -87,7 +87,7 @@ export function Header({
           >
             <ShoppingBagIcon></ShoppingBagIcon>
             {cartQuantity ? (
-              <div className="absolute rounded-full -top-2 -right-2 bg-primary-600 w-6 h-6">
+              <div className="absolute rounded-full -top-2 -right-2 bg-primary-600 min-w-6 min-h-6 flex items-center justify-center text-xs p-1">
                 {cartQuantity}
               </div>
             ) : (


### PR DESCRIPTION
Old:
![Screenshot 2024-01-18 at 3 21 42 PM](https://github.com/vendure-ecommerce/storefront-remix-starter/assets/91455763/5c5db859-613c-4530-8d3e-fdfba96c3b8c)

New:
![Screenshot 2024-01-18 at 3 21 55 PM](https://github.com/vendure-ecommerce/storefront-remix-starter/assets/91455763/c5fb6755-b5ad-4737-a087-5fdf7d9fdb8b)
