### PR TITLE
Fix for nested routes rendering issue

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -1,5 +1,3 @@
-import { createRoutesFromFolders } from '@remix-run/v1-route-convention';
-
 /**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -11,10 +9,6 @@ const commonConfig = {
     '@remix-validated-form/with-zod',
   ],
   tailwind: true,
-  routes(defineRoutes) {
-    // uses the v1 convention, works in v1.15+ and v2
-    return createRoutesFromFolders(defineRoutes);
-  },
 };
 
 /**


### PR DESCRIPTION
Fix for nested routes rendering issue as described here: [https://github.com/vendure-ecommerce/storefront-remix-starter/issues/92](https://github.com/vendure-ecommerce/storefront-remix-starter/issues/92)

Removing manual route generation seems to have fiuxed the issue:
![image](https://github.com/user-attachments/assets/f2675e62-565e-460d-bd4f-e0d8f7683e04)

